### PR TITLE
Bugfix/fix registered bug in trello

### DIFF
--- a/src/components/IndexComponents/IndexCafeteria.js
+++ b/src/components/IndexComponents/IndexCafeteria.js
@@ -95,6 +95,10 @@ const Menu = styled.div`
   color: #252525;
   text-align: left;
   margin-bottom: 4px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const ShowMore = styled.div`

--- a/src/components/IndexComponents/IndexCafeteria.js
+++ b/src/components/IndexComponents/IndexCafeteria.js
@@ -99,6 +99,7 @@ const Menu = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 50%;
 `;
 
 const ShowMore = styled.div`

--- a/src/components/IndexComponents/IndexTopBoard.js
+++ b/src/components/IndexComponents/IndexTopBoard.js
@@ -611,6 +611,11 @@ export default function IndexTopBoard(
     window.addEventListener('resize', () => {
       setMobileFlag(window.innerWidth);
     })
+    return () => {
+      window.removeEventListener('resize', () => {
+        setMobileFlag(window.innerWidth);
+      })
+    }
   }, []);
 
   useEffect(() => {

--- a/src/components/InfoComponents/StoreDetail.js
+++ b/src/components/InfoComponents/StoreDetail.js
@@ -5,7 +5,6 @@ import parse from 'html-react-parser';
 const Container = styled.div`
   border-top: #f7941e 5px solid;
   width: 100%;
-  height: 100%;
   min-height: calc(100vh - 84px);
   margin: auto;
 
@@ -392,7 +391,7 @@ export default function StoreDetail ({
             <>
               <StoreMenuTitle>MENU</StoreMenuTitle>
               <StoreMenuCardWrapper>
-                {store.menus.map(
+                {store.menus.filter(menu => menu.price_type).map(
                   menu => {
                     return menu.price_type.map(
                         price => ({...price, name: menu.name})

--- a/src/components/PromotionComponents/PromotionDetail.js
+++ b/src/components/PromotionComponents/PromotionDetail.js
@@ -231,7 +231,7 @@ const PromotionEditButton = styled(Link)`
   padding: 5px 0;
   font-size: 12px;
   font-weight: normal;
-  line-height: 1.5;
+  line-height: 1.75;
   text-decoration: none;
   text-align: center;
   color: #252525;

--- a/src/components/PromotionComponents/PromotionEdit.js
+++ b/src/components/PromotionComponents/PromotionEdit.js
@@ -563,6 +563,7 @@ const EditButton = styled.input.attrs({type: 'button'})`
     padding: 16px;
     border: none;
     right: 0;
+    z-index: 21;
   }
 `;
 
@@ -593,6 +594,7 @@ const CancelButton = styled.input.attrs({type: 'button'})`
     padding: 16px;
     border: none;
     left: 0;
+    z-index: 21;
   }
 `;
 

--- a/src/containers/PromotionContainers/PromotionEditContainer.js
+++ b/src/containers/PromotionContainers/PromotionEditContainer.js
@@ -234,7 +234,7 @@ export default function PromotionEditContainer({ history, match }) {
         />
       </Header>
       <PromotionEdit
-        type="등록"
+        type="수정"
         promotion={promotion}
         shops={shops}
         helpButtonFlag={helpButtontonFlag}

--- a/src/containers/PromotionContainers/PromotionRegisterContainer.js
+++ b/src/containers/PromotionContainers/PromotionRegisterContainer.js
@@ -199,11 +199,10 @@ export default function PromotionEditContainer({ history, match }) {
   }, [error]);
 
   useEffect(() => {
-    if (post.data) {
-      if (post.data.id) {
-        console.log(post.data)
+    if (post.pendingData) {
+      if (post.pendingData.id) {
         if (window.confirm('현재 진행중인 이벤트가 있습니다.\n수정하시겠습니까?')) {
-          sessionStorage.setItem("postId", post.data.id);
+          sessionStorage.setItem("postId", post.pendingData.id);
           history.replace('/board/promotion/edit');
         } else {
           history.goBack();

--- a/src/modules/promotion.js
+++ b/src/modules/promotion.js
@@ -64,6 +64,7 @@ const initialState = {
     data: null,
     loading: false,
     error: null,
+    pendingData: null,
     totalPageNum: 0,
     pageNum: 1,
     PAGE_MAX_SIZE: 5
@@ -219,7 +220,7 @@ export default function promotionReducer(state = initialState, action) {
         ...state,
         post: {
           ...state.post,
-          data: null,
+          pendingData: null,
           loading: true,
           error: null
         }
@@ -229,7 +230,7 @@ export default function promotionReducer(state = initialState, action) {
         ...state,
         post: {
           ...state.post,
-          data: action.payload,
+          pendingData: action.payload,
           loading: false,
           error: null
         }
@@ -239,7 +240,7 @@ export default function promotionReducer(state = initialState, action) {
         ...state,
         post: {
           ...state.post,
-          data: null,
+          pendingData: null,
           loading: false,
           error: action.error
         }


### PR DESCRIPTION
- indextopboard에서 생기는 메모리 누수 해결
- 주변상점 상세페이지에서 menu 배열 중 price_type이 없는 요소가 있는 경우 에러가 발생하는 현상 해결
- 홍보게시판 글쓰기 -> 진행중인 이벤트 있을 경우 뒤로 돌아가고 상세페이지 클릭하면 에러가 발생하는 현상 해결
- 메인페이지 식단 파트의 내용이 튀어나오는 것 방지