### PR TITLE
fix: Change edit action not to change post state

### DIFF
--- a/src/modules/board.js
+++ b/src/modules/board.js
@@ -263,7 +263,7 @@ export default function boardReducer(state = initialState, action) {
         data: action.payload,
         post: {
           loading: false,
-          data: action.payload.data,
+          data: null,
           error: null
         }
       }


### PR DESCRIPTION
Edit action시 post state를 변경하지 않게 하여, comment값이 유지되도록 수정함으로써, 댓글이 0개인 게시물을 수정했을 때 발생하는 오류를 수정했습니다.