### PR TITLE
Hotfix/fix store poster error

### DIFF
--- a/src/components/InfoComponents/StorePoster.js
+++ b/src/components/InfoComponents/StorePoster.js
@@ -3,13 +3,15 @@ import styled from 'styled-components';
 
 const StorePosterImage = styled.img`  
   width: 600px;
+  max-height: 100%;
   cursor: pointer;
   position: fixed;
   margin: auto;
   
   @media (max-width: 576px) {
     & {
-      width: 275px;
+      max-width: calc(100% - 68px);
+      max-height: calc(100% - 100px);
     }
   }
 `;

--- a/src/components/PromotionComponents/PromotionEdit.js
+++ b/src/components/PromotionComponents/PromotionEdit.js
@@ -118,6 +118,9 @@ const ShopSelectWrapper = styled.div`
     border-radius: 0;
     line-height: 1.4;
     text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   
   &::after {


### PR DESCRIPTION
- 주변상점에서의 포스터 이미지의 max-width와 max-height를 설정했습니다 (7b8ff93).
- 홍보게시판 수정에서 상점 이름이 길 경우 dropdown을 빠져나가는 버그를 고쳤습니다 (e9b241e).