### PR TITLE
feat : Add if not menu content display none img and text

### DIFF
--- a/src/components/IndexComponents/IndexCafeteria.js
+++ b/src/components/IndexComponents/IndexCafeteria.js
@@ -184,21 +184,32 @@ const Menu = styled.div`
 
 
 const NoMenu = styled.div`
-  height: 18px;
+  height: 31px;
   font-family: "NanumBarunGothic", serif;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: normal;
   font-style: normal;
   font-stretch: normal;
   line-height: 1.2;
   letter-spacing: normal;
-  color: #9fa9b3;
+  color: #252525;
   text-align: center;
-  margin: 27px 0 0 -15px;
+  margin: 15px 0 0 -15px;
   
   @media(max-width: 576px){
-    margin: 27px 0 0 -19px;
+    margin: 8px 0 0 -19px;
   }
+`
+const NoMenuContent = styled.div`
+  text-align: center;
+  margin-top: 21px;
+`
+const NoMenuImage = styled.img.attrs({
+  src: "https://static.koreatech.in/assets/img/ic-none.png"
+})`
+ width: 52px;
+ height: 47px;
+ margin-left: -19px;
 `
 
 export default React.memo(function IndexCafeteria({
@@ -276,9 +287,14 @@ export default React.memo(function IndexCafeteria({
                           )
                         })}
                         {!menu &&
-                        <NoMenu>
-                          오늘의 식단 정보가 없습니다!
-                        </NoMenu>
+                        <NoMenuContent>
+                          <NoMenuImage/>
+                          <NoMenu>
+                            식단이 제공되지 않아
+                            <div text={<br/>}/>
+                            표시할 수 없습니다.
+                          </NoMenu>
+                        </NoMenuContent>
                         }
                       </>}
                     </Fragment>

--- a/src/components/IndexComponents/IndexCafeteria.js
+++ b/src/components/IndexComponents/IndexCafeteria.js
@@ -291,7 +291,7 @@ export default React.memo(function IndexCafeteria({
                           <NoMenuImage/>
                           <NoMenu>
                             식단이 제공되지 않아
-                            <div text={<br/>}/>
+                            <br/>
                             표시할 수 없습니다.
                           </NoMenu>
                         </NoMenuContent>


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->
웹
![image](https://user-images.githubusercontent.com/50792467/170868536-8f94f469-436b-41c6-af5e-8193b76d208b.png)
모바일 웹
<img width="507" alt="스크린샷 2022-05-29 오후 9 33 27" src="https://user-images.githubusercontent.com/50792467/170868581-f3f2c801-bd32-4a38-8c9d-243902519760.png">


## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->
s3에 ic- none이미지 추가
메뉴 없을 시 텍스트 변경 및 이미지 확인 가능하도록 함.

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
