### PR TITLE
코인 시간표 기능 중 여백 제거

### DIFF
--- a/src/components/TimeTableComponents/LectureListTable.js
+++ b/src/components/TimeTableComponents/LectureListTable.js
@@ -11,7 +11,7 @@ const StyledTable = styled.div`
   text-align: left;
   word-break: break-all;
   border-bottom: #858585 1px solid;
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
   margin-top: 14px;

--- a/src/components/TimeTableComponents/LectureListTable.js
+++ b/src/components/TimeTableComponents/LectureListTable.js
@@ -14,13 +14,9 @@ const StyledTable = styled.div`
   overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
-  margin-top: 14px;
+  margin-top: 14px; 
   scrollbar-width: none;
   -ms-overflow-style: none;
-  
-  ::-webkit-scrollbar {
-    width: 0;
-  }
 `;
 
 const TableHeaderRow = styled.div`


### PR DESCRIPTION
<문제사항>
코인 시간표 기능 중 발생한 여백 수정
![image](https://user-images.githubusercontent.com/50792467/179946554-9a02c7d8-dd56-4298-93e5-79458bfb6a72.png)

<수정결과>
![image](https://user-images.githubusercontent.com/50792467/179947013-7d5fff7d-18f4-4bc6-a121-2858179c3dab.png)

<해결방법>
방법 : 여백이 발생한 StyledTabled에서 overflow-x 속성 변경(scroll => auto)
발생 이유 : overflow-x: scroll 속성에는 scroll 생성이 이루어지고 해당 부분이 padding값을 통해 자리를 차지하게 된다. 
그리고 이 부분에서 ::-webkit-scollbar 속성에서 width를 0으로 설정되어 스크롤바임을 시각적으로 확인할 수 없었음
auto로 처리함으로 여백 제거 완료.
또한 scroll 속성이 없음으로 필요가 없는 ::webkit-scrollbar 속성 제거.

<참고>
[MDN: overflow-x](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x) 
[MDN: ::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar)