### PR TITLE
로그인페이지 : 자동로그인 체크 불가 에러 수정

### DIFF
--- a/src/components/UserComponents/LoginForm.js
+++ b/src/components/UserComponents/LoginForm.js
@@ -177,26 +177,24 @@ function LoginForm({
           id="autoLoginCheckBox"
         />
         <AutoLoginText
-          onClick={onToggleAutoLoginFlag}
-          htmlFor="autoLoginCheckBox">
+          onChange={onToggleAutoLoginFlag}
+          htmlFor="autoLoginCheckBox"
+        >
           자동 로그인
         </AutoLoginText>
       </AutoLoginField>
       <HelpField>
         <FindUserIdLink
           target="_blank"
-          href="https://portal.koreatech.ac.kr/kut/page/findUser.jsp">
+          href="https://portal.koreatech.ac.kr/kut/page/findUser.jsp"
+        >
           아이디 찾기
         </FindUserIdLink>
-        <FindPasswordLink to="/findpw">
-          비밀번호 찾기
-        </FindPasswordLink>
-        <SignUpLink to="/signup">
-          회원가입
-        </SignUpLink>
+        <FindPasswordLink to="/findpw">비밀번호 찾기</FindPasswordLink>
+        <SignUpLink to="/signup">회원가입</SignUpLink>
       </HelpField>
     </>
-  )
+  );
 }
 
 LoginForm.propTypes = {


### PR DESCRIPTION
<문제사항>
로그인에서 자동로그인을 눌러도 체크표시가 나오지 않음

<문제원인>
![image](https://user-images.githubusercontent.com/50792467/180384242-495f1d26-93fd-404d-a259-2f96dcf14804.png)
기능 상 자동로그인 체크 시 체크박스 뿐만 아니라 글을 클릭하였을 때도 체크가 되도록 하기 위한 처리로 보임
onChange를 사용하지 않고 onClick을 사용한 것이 원인이였음

<수정방법>
![image](https://user-images.githubusercontent.com/50792467/180384182-c5ad3d71-7c64-411a-9652-0f5ce9d4ece4.png)
onClick=>onChange로 변경하여 현재 정상 작동되도록 수정함
![image](https://user-images.githubusercontent.com/50792467/180386019-75d75750-af77-4ebe-9fb3-adfd9708eb7a.png)
