### PR TITLE
bugFix: 기존 식단 리스트 최신화 

### DIFF
--- a/src/components/IndexComponents/IndexCafeteria.js
+++ b/src/components/IndexComponents/IndexCafeteria.js
@@ -93,8 +93,8 @@ const CafeteriaContainer = styled.div`
 `;
 
 const Cafeteria = styled.div`
-  margin-bottom: 24px;
-  width: 26px;
+  margin: 8px 0;
+  width: 42px;
   font-size: 14px;
   font-weight: normal;
   font-style: normal;
@@ -156,7 +156,7 @@ const MenuContainer = styled.div`
   flex-wrap: wrap;
   width: 100%;
   box-sizing: border-box;
-  padding: 15px 0 0 19px;
+  padding: 15px 0 0 27px;
 
   @media (max-width: 576px) {
     grid-column: 1 / 3;

--- a/src/components/InfoComponents/CafeteriaMenu.js
+++ b/src/components/InfoComponents/CafeteriaMenu.js
@@ -87,12 +87,17 @@ const Date = styled.span`
   }
 `;
 
-const CafeteriaList = styled.button`
-  width: 158px;
+const CafeteriaList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+`;
+
+const CafeteriaCorseName = styled.button`
+  width: 100%;
   height: 54px;
-  border: solid ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
-  border-width: 3px 0 3px 0;
-  color: ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
+  border: solid ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
+  border-width: 3px 0;
+  color: ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
   padding: 21px auto;
   font-size: 16px;
   font-weight: bold;
@@ -200,7 +205,7 @@ const TimeButton = styled.button`
 
 const CafeteriaSection = styled.span`
   height: 10px;
-  border: solid ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
+  border: solid ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
   border-width: 0 1.5px 0 1.5px;
   font-family: AppleSDGothicNeoSB00,sans-serif;
   font-size: 13px;
@@ -211,7 +216,7 @@ const CafeteriaSection = styled.span`
   text-align: center;
   padding: 0 12px;
   line-height: 1.15;
-  color: ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
+  color: ${(props) => (props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스") ? '#f7941e' : '#175c8e'};
   background-color: #FFFFFF;
   z-index: 1;
   margin: 0 5.5px;
@@ -222,9 +227,9 @@ const CafeteriaSection = styled.span`
     position: absolute;
     height: 1px;
     background-color: rgba(
-    ${props => props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스" ? 247 : 23 },
-    ${props => props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스" ? 148 : 92 },
-    ${props => props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스" ? 30 : 142 },
+    ${props => props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스" ? 247 : 23 },
+    ${props => props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스" ? 148 : 92 },
+    ${props => props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스" ? 30 : 142 },
     0.3);
     left: 0;
     right: 0;
@@ -265,15 +270,17 @@ export default function CafeteriaMenu(
               onClick={clickNext}
               direction="next"/>
           </DateSelector>
+          <CafeteriaList>
           {cafeteriaList.map((cafeteria) => {
             return (
-              <CafeteriaList
+              <CafeteriaCorseName
                 key={cafeteria}
                 cafeteria={cafeteria}>
                 {cafeteria}
-              </CafeteriaList>
+              </CafeteriaCorseName>
             )
           })}
+          </CafeteriaList>
           <Breakfast>
             <TimeSection>
               아침

--- a/src/components/InfoComponents/CafeteriaMenuList.js
+++ b/src/components/InfoComponents/CafeteriaMenuList.js
@@ -3,9 +3,9 @@ import styled from "styled-components";
 
 const MenusContainer = styled.div`
   display: -ms-grid;
-  -ms-grid-columns: 163px 162px 163px 162px 163px 162px 160px;
+  -ms-grid-columns: repeat(5, 1fr);
   display: grid;
-  grid-template-columns: 163px 162px 163px 162px 163px 162px 160px;
+  grid-template-columns: repeat(5, 1fr);
   position: relative;
   top: -7px;
   z-index: -1;
@@ -22,9 +22,9 @@ const Menus = styled.div`
   height:100%;
   border-radius: 2px;
   background-color: rgba(
-    ${props => props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스" ? 247 : 23 },
-    ${props => props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스" ? 148 : 92 },
-    ${props => props.cafeteria === "능수관" || props.cafeteria === "수박여" || props.cafeteria === "2캠퍼스" ? 30 : 142 },
+    ${props => props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스" ? 247 : 23 },
+    ${props => props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스" ? 148 : 92 },
+    ${props => props.cafeteria === "능수관" || props.cafeteria === "2캠퍼스" ? 30 : 142 },
     ${props => props.time === "BREAKFAST" ? 0.03 : props.time === "LUNCH" ? 0.1 : 0.2 });
   color: black;
   padding-top: 33.8px;

--- a/src/containers/IndexContainers/IndexCafeteriaContainer.js
+++ b/src/containers/IndexContainers/IndexCafeteriaContainer.js
@@ -49,37 +49,33 @@ export default function IndexCafeteriaContainer({history}) {
   }
 
   const setMenus = useCallback(() => {
-    let koreanFood = ["","",""];
-    let oneDishFood = ["","",""];
-    let westernFood = ["","",""];
-    let specialFood = ["","",""];
+    let corseA = ["","",""];
+    let corseB = ["","",""];
+    let corseC = ["","",""];
+    let neungSu = ["","",""];
 
     data.map((menus)=> {
       console.log(menus)
-      if(menus.place === "한식"){
-        setMenuByType(koreanFood, menus)
+      if(menus.place === "A코너"){
+        setMenuByType(corseA, menus)
       }
-      if(menus.place === "일품식"){
-        setMenuByType(oneDishFood, menus)
+      if(menus.place === "B코너"){
+        setMenuByType(corseB, menus)
       }
-      if(menus.place === "양식"){
-        setMenuByType(westernFood, menus)
+      if(menus.place === "C코너"){
+        setMenuByType(corseC, menus)
       }
-      if(menus.place === "특식"){
-        setMenuByType(specialFood, menus)
+      if(menus.place === "능수관"){
+        setMenuByType(neungSu, menus)
       }
     })
-    setAllMenus([koreanFood,oneDishFood,westernFood,specialFood]);
+    setAllMenus([corseA, corseB, corseC, neungSu]);
   })
-
-  useEffect(()=> {
-    console.log(allMenus)
-  },[allMenus])
 
   return (
     <IndexCafeteria
       history={history}
-      cafeteriaList={["한식","일품","양식","특식"]}
+      cafeteriaList={["A코너","B코너","C코너","능수관"]}
       selected={selected}
       setSelected={setSelected}
       type={type}

--- a/src/containers/InfoContainers/CafeteriaMenuContainer.js
+++ b/src/containers/InfoContainers/CafeteriaMenuContainer.js
@@ -7,7 +7,7 @@ export default function CafeteriaMenuContainer() {
   const timezoneOffset = new Date().getTimezoneOffset() * 60000;
   const [today,setToday] = useState(new Date(Date.now() - timezoneOffset));
   const dispatch = useDispatch();
-  const cafeteriaList = ["한식","일품식","양식","특식","능수관","수박여","2캠퍼스"];
+  const cafeteriaList = ["A코너","B코너","C코너","능수관","2캠퍼스"];
   const {data, loading, error} = useSelector(state => state.cafeteriaMenuReducer.cafeteriaMenus);
 
   function getApiDate(dateString) {


### PR DESCRIPTION
### Request
-----
- [x] 기존 식단 구성 리스트 `일품, 양식, 한식, 특식, 수박여, 능수관, 2캠퍼스` 를 `A코너, B코너, C코너, 능수관, 2캠퍼스`로 수정.
- [x] 리스트의 수에 따라 유동적으로 웹페이지 UI가 보이도록 css 개선
- [x] 리스트 값들의 문자 수 증가에 따라 width 수정 
- [x] 불필요한 코드 (ex. `console.log`) 삭제

### Description & ScreenShot
----
* index페이지 식단(PC)
![스크린샷 2022-09-25 오전 2 38 29](https://user-images.githubusercontent.com/51052049/192111689-19aa2de2-4e4a-4e93-be31-0e6af320309b.png)
* index페이지 식단(Mobile)
![스크린샷 2022-09-25 오전 2 39 08](https://user-images.githubusercontent.com/51052049/192111717-9b405e2e-a6cd-4549-9890-e797ab2c97a8.png)
* 식단 페이지(PC)
![스크린샷 2022-09-25 오전 2 38 39](https://user-images.githubusercontent.com/51052049/192111769-c9297afd-5b6a-49c0-87dc-8b8dede1c954.png)
* 식단 페이지(Mobile)
![스크린샷 2022-09-25 오전 2 38 51](https://user-images.githubusercontent.com/51052049/192111798-916f3b1e-32e0-4fa6-8328-e576f56ba7f4.png)